### PR TITLE
Fix GitHub Actions code style check error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
   fmt:
     name: code style check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.0"
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Fixes the error: `Input required and not supplied: php-version`.